### PR TITLE
Fixes bug in angular-view sub-generator

### DIFF
--- a/angular-view/index.js
+++ b/angular-view/index.js
@@ -99,7 +99,7 @@ var ViewGenerator = yeoman.generators.NamedBase.extend({
 				// Save route file
 				this.writeFileFromString(routesFileContent, routesFilePath);
 			} else {
-				this.template('_routes.js', 'public/modules/' + this.slugifiedModuleName + '/views/routes.js')
+				this.template('_routes.js', 'public/modules/' + this.slugifiedModuleName + '/config/routes.js')
 			}
 		}
 	},


### PR DESCRIPTION
In the angular-view sub-generator, if the routes.js isn't found in the config directory, a new template is created in the views/. This has to be in the config/ as per the set convention.
