### PR TITLE
unauthenticated users should not see the edition buttons

### DIFF
--- a/crud-module/templates/angular-module/views/_.view.client.view.html
+++ b/crud-module/templates/angular-module/views/_.view.client.view.html
@@ -2,7 +2,7 @@
 	<div class="page-header">
 		<h1 data-ng-bind="<%= camelizedSingularName %>.name"></h1>
 	</div>
-	<div class="pull-right" data-ng-show="authentication.user._id == <%= camelizedSingularName %>.user._id">
+	<div class="pull-right" data-ng-show="((authentication.user) && (authentication.user._id == <%= camelizedSingularName %>.user._id))">
 		<a class="btn btn-primary" href="/#!/<%= slugifiedPluralName %>/{{<%= camelizedSingularName %>._id}}/edit">
 			<i class="glyphicon glyphicon-edit"></i>
 		</a>


### PR DESCRIPTION
The backend enforces that a user is Login and has Authorization to edit a resource. The frontend omitted to enforce the user is Login. This was a issue on a resource without user field, an imported resource for instance.
