### PR TITLE
fixed typos

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -38,7 +38,7 @@ var MeanGenerator = yeoman.generators.Base.extend({
 			default: 'Full-Stack JavaScript with MongoDB, Express, AngularJS, and Node.js'
 		}, {
 			name: 'appKeywords',
-			message: 'How would you describe your application in comma seperated key words?',
+			message: 'How would you describe your application in comma separated key words?',
 			default: 'MongoDB, Express, AngularJS, Node.js'
 		}, {
 			name: 'appAuthor',

--- a/vertical-module/templates/client/views/_.list.client.view.html
+++ b/vertical-module/templates/client/views/_.list.client.view.html
@@ -3,7 +3,7 @@
         <h1><%= humanizedPluralName %></h1>
     </div>
     <div class="list-group">
-        <a data-ng-repeat="<%= camelizedSingularName %> in <%= camelizedPluralName %>" data-ng-href="#!/<%= slugifiedPluralName %>/{{<%= camelizedSingularName %>._id}}" class="list-group-item">
+        <a data-ng-repeat="<%= camelizedSingularName %> in <%= camelizedPluralName %>" data-ng-href="/#!/<%= slugifiedPluralName %>/{{<%= camelizedSingularName %>._id}}" class="list-group-item">
 			<small class="list-group-item-text">
 				Posted on
 				<span data-ng-bind="<%= camelizedSingularName %>.created | date:'medium'"></span>


### PR DESCRIPTION
1. In the main generator menu- Changed "seperated" to "separated".
2. In the vertical module generator, list html- Added an initial backslash data-ng-href pointing to the view html, so that the link will work properly.
