### PR TITLE
fixed yeoman broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ So, we set out to work on the features we thought every developer needs, and we 
 
 ## Getting Started
 
-Before you begin make sure you have the [yo scaffolding tool](http://yeoman.io/generators.html) installed(As it is part of the Yeoman tool set you might have installed it before). To globally install *yo* you will need to use npm:
+Before you begin make sure you have the [yo scaffolding tool](http://yeoman.io/generators/) installed(As it is part of the Yeoman tool set you might have installed it before). To globally install *yo* you will need to use npm:
 
 
 ```


### PR DESCRIPTION
Fixes a broken link to the yeoman generator page, as mentioned in this issue: meanjs/mean#270
