### PR TITLE
Nested states generator

### DIFF
--- a/angular-route/index.js
+++ b/angular-route/index.js
@@ -38,7 +38,9 @@ var ViewGenerator = yeoman.generators.NamedBase.extend({
 
 			this.slugifiedModuleName = this._.slugify(this.moduleName);
 			this.humanizedModuleName = this._.humanize(this.moduleName);
-
+			
+			this.stateName = this.name;
+			
 			this.slugifiedName = this._.slugify(this._.humanize(this.name));
 			this.classifiedName = this._.classify(this.slugifiedName);
 			this.humanizedName = this._.humanize(this.slugifiedName);

--- a/angular-route/templates/_.client.route.js
+++ b/angular-route/templates/_.client.route.js
@@ -1,5 +1,5 @@
 $stateProvider.
-		state('<%= slugifiedName %>', {
+		state('<%= stateName %>', {
 			url: '/<%= slugifiedRoutePath %>',
 			templateUrl: 'modules/<%= slugifiedModuleName %>/views/<%= slugifiedViewName %>.client.view.html'
 		}).

--- a/angular-route/templates/_.client.routes.js
+++ b/angular-route/templates/_.client.routes.js
@@ -5,7 +5,7 @@ angular.module('<%= slugifiedModuleName %>').config(['$stateProvider',
 	function($stateProvider) {
 		// <%= humanizedModuleName %> state routing
 		$stateProvider.
-		state('<%= slugifiedName %>', {
+		state('<%= stateName %>', {
 			url: '/<%= slugifiedRoutePath %>',
 			templateUrl: 'modules/<%= slugifiedModuleName %>/views/<%= slugifiedViewName %>.client.view.html'
 		});


### PR DESCRIPTION
Any chance of having nested routes using this PR approach?
The state name is the param in route generator (nothing special)

So I can do
~~~
$ yo meanjs:angular-route app
? Which module does this route belongs to? core
? What do you want your route path to be? app
? What do you want to call your view? app
? What do you want to call your controller? App


$ yo meanjs:angular-route app.nested
? Which module does this route belongs to? core
? What do you want your route path to be? app-nested
? What do you want to call your view? app-nested
? What do you want to call your controller? AppNested

~~~

And results
~~~
$stateProvider.
state('app', {
	url: '/app',
	templateUrl: 'modules/core/views/app.client.view.html'
}).
state('app.nested', {
	url: '/app-nested',
	templateUrl: 'modules/core/views/app-nested.client.view.html'
})
~~~

