### PR TITLE
Replace for pull 53: confirm before delete, using modal instead of JS confirm

### DIFF
--- a/crud-module/index.js
+++ b/crud-module/index.js
@@ -114,6 +114,7 @@ var ModuleGenerator = yeoman.generators.NamedBase.extend({
 		this.template('angular-module/views/_.create.client.view.html', 'public/modules/' + this.slugifiedPluralName + '/views/create-' + this.slugifiedSingularName + '.client.view.html');
 		this.template('angular-module/views/_.edit.client.view.html', 'public/modules/' + this.slugifiedPluralName + '/views/edit-' + this.slugifiedSingularName + '.client.view.html');
 		this.template('angular-module/views/_.list.client.view.html', 'public/modules/' + this.slugifiedPluralName + '/views/list-' + this.slugifiedPluralName + '.client.view.html');
+		this.template('angular-module/views/_.remove.client.view.html', 'public/modules/' + this.slugifiedPluralName + '/views/remove-' + this.slugifiedSingularName + '.client.view.html');
 		this.template('angular-module/views/_.view.client.view.html', 'public/modules/' + this.slugifiedPluralName + '/views/view-' + this.slugifiedSingularName + '.client.view.html');
 
 		// Render angular module definition

--- a/crud-module/templates/angular-module/controllers/_.client.controller.js
+++ b/crud-module/templates/angular-module/controllers/_.client.controller.js
@@ -1,8 +1,8 @@
 'use strict';
 
 // <%= humanizedPluralName %> controller
-angular.module('<%= slugifiedPluralName %>').controller('<%= classifiedPluralName %>Controller', ['$scope', '$stateParams', '$location', 'Authentication', '<%= classifiedPluralName %>',
-	function($scope, $stateParams, $location, Authentication, <%= classifiedPluralName %>) {
+angular.module('<%= slugifiedPluralName %>').controller('<%= classifiedPluralName %>Controller', ['$scope', '$stateParams', '$location', '$modal', 'Authentication', '<%= classifiedPluralName %>',
+	function($scope, $stateParams, $location, $modal, Authentication, <%= classifiedPluralName %>) {
 		$scope.authentication = Authentication;
 
 		// Create new <%= humanizedSingularName %>
@@ -25,19 +25,33 @@ angular.module('<%= slugifiedPluralName %>').controller('<%= classifiedPluralNam
 
 		// Remove existing <%= humanizedSingularName %>
 		$scope.remove = function(<%= camelizedSingularName %>) {
-			if ( <%= camelizedSingularName %> ) { 
-				<%= camelizedSingularName %>.$remove();
+            $modal.open({
+                templateUrl: 'modules/<%= slugifiedPluralName %>/views/remove-<%= slugifiedSingularName %>.client.view.html',
+                controller: function($scope, $modalInstance) {
+                    $scope.ok = function() {
+                        $modalInstance.close();
+                    };
 
-				for (var i in $scope.<%= camelizedPluralName %>) {
-					if ($scope.<%= camelizedPluralName %> [i] === <%= camelizedSingularName %>) {
-						$scope.<%= camelizedPluralName %>.splice(i, 1);
-					}
-				}
-			} else {
-				$scope.<%= camelizedSingularName %>.$remove(function() {
-					$location.path('<%= slugifiedPluralName %>');
-				});
-			}
+                    $scope.cancel = function() {
+                        $modalInstance.dismiss('cancel');
+                    };
+                }
+            })
+            .result.then(function() {
+                if ( <%= camelizedSingularName %> ) {
+                    <%= camelizedSingularName %>.$remove();
+
+                    for (var i in $scope.<%= camelizedPluralName %>) {
+                        if ($scope.<%= camelizedPluralName %> [i] === <%= camelizedSingularName %>) {
+                            $scope.<%= camelizedPluralName %>.splice(i, 1);
+                        }
+                    }
+                } else {
+                    $scope.<%= camelizedSingularName %>.$remove(function() {
+                        $location.path('<%= slugifiedPluralName %>');
+                    });
+                }
+            });
 		};
 
 		// Update existing <%= humanizedSingularName %>

--- a/crud-module/templates/angular-module/views/_.remove.client.view.html
+++ b/crud-module/templates/angular-module/views/_.remove.client.view.html
@@ -1,0 +1,10 @@
+<div class="modal-header">
+    <h3 class="modal-title">Please confirm</h3>
+</div>
+<div class="modal-body">
+    Are you sure you want to remove this item?
+</div>
+<div class="modal-footer">
+    <button type="button" class="btn btn-danger" ng-click="ok()">Remove</button>
+    <button type="button" class="btn btn-default" ng-click="cancel()">Cancel</button>
+</div>


### PR DESCRIPTION
This is a replace for the pull request #53. Instead of using a JS confirm from the view, this pull request includes usage of a $modal from the controller and a separate view for the confirmation.

I'm not completely sure I'm following the standards for the project, so any feedback is appreciated.