### PR TITLE
Update node and npm to coincide with MEAN

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: node_js
 node_js:
-  - 0.10
   - 0.12
   - 4
+  - 5
 matrix:
   allow_failures:
-    - node_js: 4
+    - node_js: 5
 sudo: false
 cache:
   apt: true

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "url": "https://github.com/meanjs"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=0.12.0",
+    "npm": ">=2.0.0"
   },
   "scripts": {
     "test": "mocha"
@@ -29,15 +30,15 @@
     "angular"
   ],
   "dependencies": {
-    "bluebird": "~2.10.0",
+    "bluebird": "~3.0.6",
     "chalk": "~1.1.1",
     "underscore.string": "~3.2.2",
-    "yeoman-generator": "~0.20.3",
-    "yo": "~1.4.8"
+    "yeoman-generator": "~0.21.1",
+    "yo": "~1.5.0"
   },
   "devDependencies": {
-    "mocha": "~2.3.2",
-    "temp": "~0.8.0"
+    "mocha": "~2.3.4",
+    "temp": "~0.8.3"
   },
   "licenses": [
     {


### PR DESCRIPTION
@codydaig forgot that we should probably do this because we don't test MEAN against 0.10 anymore. Just want to get this in before the release so people don't just install it without seeing that it should be using >=0.12 because MEAN also requires 0.12.