### PR TITLE
MEAN module subgenerator and test added

### DIFF
--- a/mean-module/index.js
+++ b/mean-module/index.js
@@ -1,0 +1,170 @@
+'use strict';
+
+var s = require('underscore.string'),
+  _ = require('lodash'),
+  mkdirp = require('mkdirp'),
+  yeoman = require('yeoman-generator');
+
+var ModuleGenerator = yeoman.generators.Base.extend({
+  init: function () {
+  },
+
+  askForModuleFolders: function () {
+    var done = this.async();
+
+    var prompts = [{
+      type: 'input',
+      name: 'name',
+      default: '',
+      message: 'What is the name of the module?',
+      validate: function(input) {
+        if (!input || typeof input !== 'string') {
+          return 'You must provide a valid non-empty name for the module!'
+        }
+        return true;
+      }
+    },{
+      type: 'checkbox',
+      name: 'clientFolders',
+      message: 'Which client-side folders would you like your module to include?',
+      choices: [{
+        value: 'addConfigFolder',
+        name: 'config',
+        checked: true
+      }, {
+        value: 'addControllersFolder',
+        name: 'controllers',
+        checked: true
+      }, {
+        value: 'addCSSFolder',
+        name: 'css',
+        checked: false
+      }, {
+        value: 'addDirectivesFolder',
+        name: 'directives',
+        checked: false
+      }, {
+        value: 'addFiltersFolder',
+        name: 'filters',
+        checked: false
+      }, {
+        value: 'addImagesFolder',
+        name: 'img',
+        checked: false
+      }, {
+        value: 'addServicesFolder',
+        name: 'services',
+        checked: true
+      }, {
+        value: 'addTestsFolder',
+        name: 'tests',
+        checked: true
+      }, {
+        value: 'addViewsFolder',
+        name: 'views',
+        checked: true
+      }]
+    }, {
+      type: 'checkbox',
+      name: 'serverFolders',
+      message: 'Which server-side folders would you like your module to include?',
+      choices: [{
+        value: 'addConfigFolder',
+        name: 'config',
+        checked: false
+      }, {
+        value: 'addControllersFolder',
+        name: 'controllers',
+        checked: true
+      }, {
+        value: 'addConfigFolder',
+        name: 'models',
+        checked: true
+      }, {
+        value: 'addPoliciesFolder',
+        name: 'policies',
+        checked: false
+      }, {
+        value: 'addRoutesFolder',
+        name: 'routes',
+        checked: true
+      }, {
+        value: 'addTestsFolder',
+        name: 'tests',
+        checked: true
+      }]
+    }];
+
+    this.prompt(prompts, function (props) {
+      // name
+      this.name = props.name;
+
+      this.clientFolders = {};
+      _.assign(this.clientFolders, props.clientFolders);
+
+      this.serverFolders = {};
+      _.assign(this.serverFolders, props.serverFolders);
+
+      done();
+    }.bind(this));
+  },
+
+  renderModule: function () {
+    this.slugifiedName = s(this.name).humanize().slugify().value();
+    this.humanizedName = s(this.slugifiedName).humanize().value();
+
+    // Create module folder
+    mkdirp.sync('modules/' + this.slugifiedName + '/client/');
+
+    // Create client module sub-folders
+    if (this.clientFolders.addConfigFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/config');
+    }
+    if (this.clientFolders.addControllersFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/controllers');
+    }
+    if (this.clientFolders.addCSSFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/css');
+    }
+    if (this.clientFolders.addDirectivesFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/directives');
+    }
+    if (this.clientFolders.addFiltersFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/filters');
+    }
+    if (this.clientFolders.addImagesFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/img');
+    }
+    if (this.clientFolders.addServicesFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/services');
+    }
+    if (this.clientFolders.addViewsFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/client/views');
+    }
+
+    if (this.clientFolders.addTestsFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/tests/client');
+    }
+
+    // Render angular module definition
+    this.template('_.client.module.js', 'modules/' + this.slugifiedName + '/client/' + this.slugifiedName + '.client.module.js');
+
+    // Create server module sub-folders
+    if (this.serverFolders.addConfigFolder ||
+        this.serverFolders.addControllersFolder ||
+        this.serverFolders.addConfigFolder ||
+        this.serverFolders.addPoliciesFolder ||
+        this.serverFolders.addRoutesFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/server/config');
+    }
+
+    if (this.serverFolders.addTestsFolder) {
+      mkdirp.sync('modules/' + this.slugifiedName + '/tests/server');
+    }
+
+    // Render server module config
+    this.template('_.server.config.js', 'modules/' + this.slugifiedName + '/server/config/' + this.slugifiedName + '.server.config.js');
+  }
+});
+
+module.exports = ModuleGenerator;

--- a/mean-module/templates/_.client.module.js
+++ b/mean-module/templates/_.client.module.js
@@ -1,0 +1,4 @@
+'use strict';
+
+// Use application configuration module to register a new module
+ApplicationConfiguration.registerModule('<%= slugifiedName %>');

--- a/mean-module/templates/_.server.config.js
+++ b/mean-module/templates/_.server.config.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Module dependencies
+ */
+var path = require('path'),
+  config = require(path.resolve('./config/config'));
+
+/**
+ * <%= humanizedName %> module init function.
+ */
+module.exports = function (app, db) {
+
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "chalk": "~1.1.1",
     "ejs": "~2.3.4",
     "html-wiring": "~1.2.0",
+    "lodash": "~4.0.0",
     "mkdirp": "~0.5.1",
     "underscore.inflections": "~0.2.1",
     "underscore.string": "~3.2.2",

--- a/test/mean-module.test.js
+++ b/test/mean-module.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+var path = require('path'),
+  helpers = require('yeoman-generator').test,
+  assert = require('yeoman-generator').assert,
+  temp = require('temp').track();
+
+describe('Module Sub Generators Tests', function () {
+  this.timeout(0);
+  /**
+   * Setup the temp directory
+   */
+  before(function (done) {
+    helpers.testDirectory(path.join(__dirname, 'temp'), done);
+  });
+
+  /**
+   * Clean up temp directory
+   */
+  after(function () {
+    temp.cleanup();
+  });
+
+  describe('Generate a MEAN module with complete folder structure through the sub-generator', function () {
+    beforeEach(function (done) {
+      helpers.run(path.join(__dirname, '../mean-module'))
+        .withOptions({
+          'skip-install': true
+        })
+        .withPrompts({
+          name: 'foo',
+          clientFolders: {
+            addConfigFolder: true,
+            addControllersFolder: true,
+            addCSSFolder: true,
+            addDirectivesFolder: true,
+            addFiltersFolder: true,
+            addImagesFolder: true,
+            addServicesFolder: true,
+            addTestsFolder: true,
+            addViewsFolder: true
+          },
+          serverFolders: {
+            addConfigFolder: true,
+            addControllersFolder: true,
+            addModelsFolder: true,
+            addPoliciesFolder: true,
+            addRoutesFolder: true,
+            addTestsFolder: true
+          }
+        })
+        .on('ready', function (generator) {
+          // this is called right before `generator.run()` is called
+        })
+        .on('end', function () {
+          done();
+        });
+    });
+
+    it('should generate an angular module and an express config file', function () {
+      assert.file('modules/foo/client/foo.client.module.js');
+      assert.file('modules/foo/server/config/foo.server.config.js');
+
+      // Checking for folders existence
+      assert.file('modules/foo/client/config/');
+      assert.file('modules/foo/client/controllers/');
+      assert.file('modules/foo/client/css/');
+      assert.file('modules/foo/client/directives/');
+      assert.file('modules/foo/client/filters/');
+      assert.file('modules/foo/client/img/');
+      assert.file('modules/foo/client/services/');
+      assert.file('modules/foo/client/views/');
+      assert.file('modules/foo/tests/client/');
+      assert.file('modules/foo/server/config');
+      assert.file('modules/foo/tests/server/');
+    });
+  });
+});


### PR DESCRIPTION
In this PR I have addressed all the issues, that were around in the previous one, plus

- Added `Underscore` library to dependencies for its `extend` function
- Reworked `this.prompt` and following folders creation function to be less verbose
- Completely isolated client and server folder prompts from each other in objects
- Added tests for folder existence

In such state this generator looks like a good CRUD generator base to me, along with it being a standalone one.