### PR TITLE
Composition Improvements

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -7,6 +7,7 @@ var Promise = require('bluebird'),
   path = require('path'),
   s = require('underscore.string'),
   generators = require('yeoman-generator'),
+  optionOrPrompt = require('yeoman-option-or-prompt'),
   log = require('./log');
 
 var exec = function (cmd) {
@@ -32,9 +33,10 @@ var versions = {
 };
 
 module.exports = generators.Base.extend({
-  
+
   init: function () {
     this.pkg = this.fs.readJSON(path.join(__dirname, '../package.json'));
+    this._optionOrPrompt = optionOrPrompt;
 
     this.on('end', function () {
       if (!this.options['skip-install']) {
@@ -73,7 +75,7 @@ module.exports = generators.Base.extend({
   welcomeMessage: function () {
     log.green('You\'re using the official MEAN.JS generator.');
   },
-
+    
   promptForVersion: function () {
     var done = this.async();
 
@@ -82,15 +84,15 @@ module.exports = generators.Base.extend({
       choices.push(v);
     }
 
-    var prompt = {
+    var prompt = [{
       type: 'list',
       name: 'version',
       message: 'What mean.js version would you like to generate?',
       choices: choices,
       default: 1
-    };
+    }];
 
-    this.prompt(prompt, function (props) {
+    this._optionOrPrompt(prompt, function (props) {
       version = props.version;
       done();
     }.bind(this));
@@ -102,13 +104,13 @@ module.exports = generators.Base.extend({
 
     log.red(version);
 
-    var prompt = {
+    var prompt = [{
       name: 'folder',
       message: 'In which folder would you like the project to be generated? This can be changed later.',
       default: 'mean'
-    };
+    }];
 
-    this.prompt(prompt, function (props) {
+    this._optionOrPrompt(prompt, function (props) {
       folder = props.folder;
       folderPath = './' + folder + '/';
       done();
@@ -160,7 +162,7 @@ module.exports = generators.Base.extend({
       default: true
     }];
 
-    this.prompt(prompts, function(props) {
+    this._optionOrPrompt(prompts, function(props) {
       this.appName = props.appName;
       this.appDescription = props.appDescription;
       this.appKeywords = props.appKeywords;

--- a/app/index.js
+++ b/app/index.js
@@ -38,6 +38,13 @@ module.exports = generators.Base.extend({
     this.pkg = this.fs.readJSON(path.join(__dirname, '../package.json'));
     this._optionOrPrompt = optionOrPrompt;
 
+    this.option('quiet', {
+      desc: 'Makes the installation process less verbose',
+      type: 'Boolean',
+      defaults: false,
+      hide: false
+    });
+
     this.on('end', function () {
       if (!this.options['skip-install']) {
         log.green('Running npm install for you....');
@@ -73,7 +80,8 @@ module.exports = generators.Base.extend({
   },
 
   welcomeMessage: function () {
-    log.green('You\'re using the official MEAN.JS generator.');
+    if (!this.options['quiet'])
+      log.green('You\'re using the official MEAN.JS generator.');
   },
     
   promptForVersion: function () {
@@ -102,7 +110,8 @@ module.exports = generators.Base.extend({
   promptForFolder: function () {
     var done = this.async();
 
-    log.red(version);
+    if (!this.options['quiet'])
+      log.red(version);
 
     var prompt = [{
       name: 'folder',
@@ -120,7 +129,8 @@ module.exports = generators.Base.extend({
   cloneRepo: function () {
     var done = this.async();
 
-    log.green('Cloning the MEAN repo.......');
+    if (!this.options['quiet'])
+      log.green('Cloning the MEAN repo.......');
 
     exec('git clone --branch ' + versions[version] + ' https://github.com/meanjs/mean.git ' + folder)
       .then(function () {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "underscore.inflections": "~0.2.1",
     "underscore.string": "~3.2.2",
     "yeoman-generator": "~0.21.1",
+    "yeoman-option-or-prompt": "^1.0.2",
     "yo": "~1.5.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Developers may want to [compose](http://yeoman.io/authoring/composability.html) the meanjs generator into their Yeoman projects.

Composing the meanjs generator automatically leads end-users through the configuration process. Using [optionOrPrompt](https://github.com/artefact-group/yeoman-option-or-prompt) allows developers to preselect prompt values. 
Additionally, users can supply options on the command line. This may help "super-users" who to skip the interactive process.

Even with all the prompts preselected, the meanjs generator prints information that can interrupt its parents' compositions. A `--quiet` option was added to skip these logs.

If these improvements are well-received, I'll extend `optionOrPrompt` and `--quiet` to the sub-generators.