### PR TITLE
Bump to 0.4.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-meanjs",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "MEAN.JS Official Yeoman Generator",
   "main": "app/index.js",
   "repository": "meanjs/generator-meanjs",


### PR DESCRIPTION
Fixes eslint errors.

This bump will need to get merged and published, but I do not have permission to publish new versions on npm.