### PR TITLE
Fixing plural issue in test templates

### DIFF
--- a/crud-module/templates/tests/server/_.server.routes.tests.js
+++ b/crud-module/templates/tests/server/_.server.routes.tests.js
@@ -83,10 +83,10 @@ describe('<%= humanizedSingularName %> CRUD tests', function () {
 
             // Get a list of <%= humanizedPluralName %>
             agent.get('/api/<%= camelizedPluralName %>')
-              .end(function (<%= camelizedSingularName %>sGetErr, <%= camelizedSingularName %>sGetRes) {
-                // Handle <%= humanizedSingularName %> save error
-                if (<%= camelizedSingularName %>sGetErr) {
-                  return done(<%= camelizedSingularName %>sGetErr);
+              .end(function (<%= camelizedPluralName %>GetErr, <%= camelizedPluralName %>GetRes) {
+                // Handle <%= humanizedPluralName %> save error
+                if (<%= camelizedPluralName %>GetErr) {
+                  return done(<%= camelizedPluralName %>GetErr);
                 }
 
                 // Get <%= humanizedPluralName %> list


### PR DESCRIPTION
Corrected some logic in the templates, which was incorrectly pluralizing entities in some edge case scenarios.