### PR TITLE
 Move the invocation into the parens that contain the function

### DIFF
--- a/mean-module/templates/_.client.module.js
+++ b/mean-module/templates/_.client.module.js
@@ -2,4 +2,4 @@
   'use strict';
 
   app.registerModule('<%= slugifiedName %>');
-})(ApplicationConfiguration);
+}(ApplicationConfiguration));


### PR DESCRIPTION
Currently throws error in eslint, meanjs0.5.0-beta