### PR TITLE
Simple test enhancement

### DIFF
--- a/crud-module/templates/tests/server/_.server.routes.tests.js
+++ b/crud-module/templates/tests/server/_.server.routes.tests.js
@@ -301,7 +301,10 @@ describe('<%= humanizedSingularName %> CRUD tests', function () {
     var <%= camelizedSingularName %>Obj = new <%= classifiedSingularName %>(<%= camelizedSingularName %>);
 
     // Save the <%= humanizedSingularName %>
-    <%= camelizedSingularName %>Obj.save(function () {
+    <%= camelizedSingularName %>Obj.save(function (err) {
+      if (err) {
+        done(err);
+      }
       // Try deleting <%= humanizedSingularName %>
       request(app).delete('/api/<%= camelizedPluralName %>/' + <%= camelizedSingularName %>Obj._id)
         .expect(403)


### PR DESCRIPTION
I'm proposing this small change to help diagnose ignored save errors while testing CRUD module server routes, specifically testing the case that covers someone 'should not be able to delete an <%= humanizedSingularName %> if not signed in'.  I'm working on a project where the request param and model property names don't match in all cases, and having this change in place helped me diagnose an issue that had taken an embarrassingly long time to fix.