### PR TITLE
Fixing `Page not found` problem for meanjs 5.0

### DIFF
--- a/crud-module/templates/client/services/_.client.service.js
+++ b/crud-module/templates/client/services/_.client.service.js
@@ -9,7 +9,7 @@
   <%= classifiedPluralName %>Service.$inject = ['$resource'];
 
   function <%= classifiedPluralName %>Service($resource) {
-    return $resource('api/<%= slugifiedPluralName %>/:<%= camelizedSingularName %>Id', {
+    return $resource('/api/<%= slugifiedPluralName %>/:<%= camelizedSingularName %>Id', {
       <%= camelizedSingularName %>Id: '@_id'
     }, {
       update: {


### PR DESCRIPTION
POST fails without / at the beginning of path In meanjs 5.0 and user is headed toward page not found.